### PR TITLE
Add the missing links to the shield images + add information about upcoming workshop series

### DIFF
--- a/_pages/bs/index.md
+++ b/_pages/bs/index.md
@@ -9,6 +9,16 @@ toc: true
 ## Braunschweiger RSE Community
 Welcome! We are Research Software Engineers from Braunschweig. You are welcome to get in touch with us. We would be happy to receive questions, discussions and, of course, participation. The meeting is currently mostly organized by people involved with the Suresoft project, but everyone else is invited to join as well.
 
+## News
+### HeFDI Code School 'Sustainable Research Software'
+SURESOFT is part of the HeFDI Code School 'Sustainable Research Software' and offers a series of workshops on research software engineering practices. The workshops are open to everyone and will be held online. The first workshop will be held on the 12th of May 2023.
+- May 12 - Scientific Software Development is not a Jenga game!
+- May 26 - Clean Code and Refactoring
+- June 23 - Introduction to Software Testing
+- July 07 - Continuous Integration and Test Driven Development
+  
+More information can be found on the [HeFDI Code School website](https://www.uni-marburg.de/en/hefdi/aktuelles/news/hefdi-suresoft-workshops-announcements).
+
 ## SURESOFT
 
 ![](SURESOFT.png){:width="300px"}

--- a/_pages/bs/index.md
+++ b/_pages/bs/index.md
@@ -19,10 +19,10 @@ We offer:
 - in person code reviews
 - discussions and more ...
 
-![Website](https://img.shields.io/website?up_message=online&url=https%3A%2F%2Fsuresoft.dev) 
+[![Website](https://img.shields.io/website?up_message=online&url=https%3A%2F%2Fsuresoft.dev)](https://suresoft.dev)
 
 ## Get in Touch
-![Matrix](https://img.shields.io/matrix/suresoft-general:matrix.org)
+[![Matrix](https://img.shields.io/matrix/suresoft-general:matrix.org)](https://matrix.to/#/#suresoft-general:matrix.org)
 
 **Mailingliste**: [https://lists.tu-braunschweig.de/sympa/info/musen-rse](https://lists.tu-braunschweig.de/sympa/info/musen-rse) 
 


### PR DESCRIPTION
I forgot to add the URLs to the shield images for
- the website
- the matrix chat

Add "news" section containing information about the new upcoming workshop series: The Hefi code school.

