### PR TITLE
Specify webrick as a dependency in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,5 @@ end
 
 # For local access for customisation
 gem "minimal-mistakes-jekyll", "~> 4.19"
+
+gem "webrick", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,6 +254,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
@@ -266,6 +267,7 @@ DEPENDENCIES
   jemoji
   minimal-mistakes-jekyll (~> 4.19)
   tzinfo-data
+  webrick (~> 1.8)
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
When trying to build the website for the first time, I got the following error:

```
$ bundle exec jekyll serve
Configuration file: /home/gc/repos/rse/chapter/_config.yml
Top level ::CompositeIO is deprecated, require 'multipart/post' and use `Multipart::Post::CompositeReadIO` instead!
Top level ::Parts is deprecated, require 'multipart/post' and use `Multipart::Post::Parts` instead!
            Source: /home/gc/repos/rse/chapter
       Destination: /home/gc/repos/rse/chapter/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
      Remote Theme: Using theme mmistakes/minimal-mistakes
   GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data.
                    done in 8.406 seconds.
 Auto-regeneration: enabled for '/home/gc/repos/rse/chapter'
/home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve/servlet.rb:3:in `require': cannot load such file -- webrick (LoadError)
	from /home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve/servlet.rb:3:in `<top (required)>'
	from /home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:184:in `require_relative'
	from /home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:184:in `setup'
	from /home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:102:in `process'
	from /home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:93:in `block in start'
	from /home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:93:in `each'
	from /home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:93:in `start'
	from /home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:75:in `block (2 levels) in init_with_program'
	from /home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
	from /home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
	from /home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
	from /home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
	from /home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
	from /home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/exe/jekyll:15:in `<top (required)>'
	from /home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/bin/jekyll:25:in `load'
	from /home/gc/repos/rse/chapter/vendor/bundle/ruby/3.0.0/bin/jekyll:25:in `<main>'
```

I followed [this StackOverflow answer](https://stackoverflow.com/a/66013726/2254346) to add webrick to the Gemfile, by running `bundle add webrick`. This modified both the `Gemfile` and `Gemfile.lock` (both committed already in this repository).

After applying this change, I can build the website normally.