### PR TITLE
Update the Munich chapter page for 2023

### DIFF
--- a/_pages/muc/index.md
+++ b/_pages/muc/index.md
@@ -1,19 +1,44 @@
 ---
-title: Münchner RSE Community
+title: Munich RSE Community
 author_profile: false
 permalink: /muc/
 layout: single
 ---
 
-Wir organisieren uns hauptsächlich über die
-[Mailingliste](https://lists.lrz.de/mailman/listinfo/rse).  Alle sind herzlich
-eingeladen über Events, Stellenausschreibungen, Ideen oder anderes zu
-berichten/diskutieren.
+Our group is the place to meet other [research software engineers](https://de-rse.org/en/) in Munich. We aim for a meeting every two months, followed by dinner and networking.
 
+Our meetings include short talks about anything related to RSE (research data management, software development, teaching/training, and more), as well as open discussions on topics brought into the agenda by any attendee.
 
-- [Blog post](https://www.de-rse.org/blog/2019/02/26/neue-rse-gruppen-in-m%C3%BCnchen-und-m%C3%BCnster.html)
-- [Mailingliste](https://lists.lrz.de/mailman/listinfo/rse)
-- Kontakt
-  - [Heidi Seibold](https://www.osc.uni-muenchen.de/members/individual-members/seibold1/index.html)
-  - [Bernd Bischl](http://www.compstat.statistik.uni-muenchen.de/people/bischl/)
-  - [Tobias Weber](https://tobias.weber.userweb.mwn.de)
+## News
+
+**Next meeting:** October 12, 2023, 17:30-19:00 at the LMU University Library, [Room F324, Geschwister-Scholl-Platz 1](https://www.lmu.de/raumfinder/#/building/bw0000/map?room=003003324_).
+
+We plan two talks:
+
+- Raphael Ritz: NFDI Jupyter Hub
+- Benjamin Rodenberg: Code Ocean
+
+After the talks/discussion, we will continue to a restaurant nearby. Join the [mailing list of our chapter](https://lists.lrz.de/mailman/listinfo/rse) to learn more.
+
+## Past activity
+
+- 2023-06-29: Second meeting in 2023, at LMU - [Meeting notes](https://pad.okfn.de/p/rse-mus-meetup2-23)
+  - Open discussion about [DataCite](https://datacite.org/) and ways to cite software, the [NFDI](https://www.nfdi.de/) initiative and the RSE working group, the [de-RSE Unconference](https://un-derse23.sciencesconf.org/), and the Digital Research Academy.
+- 2023-03-15: First meeting in 2023, at LMU - [Meeting notes](https://pad.okfn.de/p/rse-muc-meetup1-23)
+  - Talk by Michael Franke: Software Management Plans
+  - Talk by Gerasimos Chourdakis: [Continuous Integration with GitHub Actions in preCICE](http://go.tum.de/389945)
+- 2019-03-11: First attempt for a regular meeting / Stammtisch at a restaurant (continued for 1-2 more evenings)
+- 2019-02-26: First [Blog post](https://www.de-rse.org/blog/2019/02/26/neue-rse-gruppen-in-m%C3%BCnchen-und-m%C3%BCnster.html) about our group, following a meeting at LRZ
+
+## Contact
+
+We organize ourselves mainly over the [Mailing list](https://lists.lrz.de/mailman/listinfo/rse). Definitely join us there to learn about upcoming events and other activities.
+
+For questions regarding the group, feel free to contact, for example:
+  - [Heidi Seibold](https://heidiseibold.com/)
+  - [Martin Spenger](https://www.ub.uni-muenchen.de/ueber-die-ub/kontakt/personen/spenger/index.html) - LMU
+  - [Gerasimos Chourdakis](https://www.cs.cit.tum.de/en/sccs/people/gerasimos-chourdakis/) - TUM
+
+**Sprache:** Um die Reichweite der Gruppe zu maximieren und mit Rücksicht auf die vielen nicht-deutschen Studenten, Doktoranden und Forscher in München, ist die Arbeitssprache der Gruppe Englisch. Natürlich bleibt Deutsch immer eine Option für die Diskussionen.
+
+[Edit this page](https://github.com/DE-RSE/chapter/blob/master/_pages/muc/index.md)

--- a/_pages/muc/index.md
+++ b/_pages/muc/index.md
@@ -23,7 +23,7 @@ After the talks/discussion, we will continue to a restaurant nearby. Join the [m
 ## Past activity
 
 - 2023-06-29: Second meeting in 2023, at LMU - [Meeting notes](https://pad.okfn.de/p/rse-mus-meetup2-23)
-  - Open discussion about [DataCite](https://datacite.org/) and ways to cite software, the [NFDI](https://www.nfdi.de/) initiative and the RSE working group, the [de-RSE Unconference](https://un-derse23.sciencesconf.org/), and the Digital Research Academy.
+  - Open discussion about [DataCite](https://datacite.org/) and ways to cite software, the [NFDI](https://www.nfdi.de/) initiative and the RSE working group, the [de-RSE Unconference](https://un-derse23.sciencesconf.org/), and the [Digital Research Academy](https://heidiseibold.ck.page/posts/feedback-wanted-building-a-digital-research-academy).
 - 2023-03-15: First meeting in 2023, at LMU - [Meeting notes](https://pad.okfn.de/p/rse-muc-meetup1-23)
   - Talk by Michael Franke: Software Management Plans
   - Talk by Gerasimos Chourdakis: [Continuous Integration with GitHub Actions in preCICE](http://go.tum.de/389945)


### PR DESCRIPTION
Our group started meeting again in 2023, and we need more content on the respective chapter, as well as a central place to keep the history of our activities.

Summary of the changes and some design choices:

- Converted the page to English, as this is the working language of our group. I added a respective note at the end, mostly for inclusivity reasons (auto-translated from English by DeepL, feel free to adjust).
- Added a link to the respective file in the repository, to make future edits much easier.
- Summary is very short, and news are at the top. The summary links to the English version of the de-RSE landing page, as this will probably be the first encounter some people will have with the term RSE.
- Past activity includes topics we discussed, as well as any links to slides and notes. This is to be able to find the related notes quicker.
- Updated the contact people to some examples of currently active people at LMU and TUM. I would even remove the section, but I see that every Chapter defines one, and is probably needed for logistics.

This is how the page looks like locally:

![Screenshot 2023-06-30 at 12-18-35 Munich RSE Community](https://github.com/DE-RSE/chapter/assets/4943683/1858ba12-cd47-47dc-9160-650f8cf4375b)

cc @HeidiSeibold