### PR TITLE
Replace talk at next MUC meeting

### DIFF
--- a/_pages/muc/index.md
+++ b/_pages/muc/index.md
@@ -16,7 +16,7 @@ Our meetings include short talks about anything related to RSE (research data ma
 We plan two talks:
 
 - Raphael Ritz: NFDI Jupyter Hub
-- ~~Benjamin Rodenberg: Code Ocean~~ (Cancelled due to conflict)
+- Hendrik Ballhausen: Privacy Preserving Computation – how to collaborate without sharing data
 
 After the talks/discussion, we will continue to a restaurant nearby. Join the [mailing list of our chapter](https://lists.lrz.de/mailman/listinfo/rse) to learn more.
 


### PR DESCRIPTION
Follow-up of #51
Replacing the cancelled talk of @BenjaminRodenberg with a talk by @Ballhausen.

Someone with write access, please review and merge :sweat_smile: 