### PR TITLE
Add MUC Dec14 meeting, archive Oct12 meeting

### DIFF
--- a/_pages/muc/index.md
+++ b/_pages/muc/index.md
@@ -11,17 +11,22 @@ Our meetings include short talks about anything related to RSE (research data ma
 
 ## News
 
-**Next meeting:** October 12, 2023, 17:30-19:00 at the LMU University Library, [Room F324, Geschwister-Scholl-Platz 1](https://www.lmu.de/raumfinder/#/building/bw0000/map?room=003003324_).
+**Next meeting:** December 14, 2023, 17:00-18:30 at the LMU University Library, [Room F324, Geschwister-Scholl-Platz 1](https://www.lmu.de/raumfinder/#/building/bw0000/map?room=003003324_).
 
-We plan two talks:
+Agenda:
 
-- Raphael Ritz: NFDI Jupyter Hub
-- Michele Martone: Brief Basic Introduction in Semantic Patching with Coccinelle
+- Talk by Hendrik Ballhausen: Privacy Preserving Computation – how to collaborate without sharing data
+- Talk by Michele Martone: The FIM (Fbi IMproved) image viewer and its development
 
-After the talks/discussion, we will continue to a restaurant nearby. Join the [mailing list of our chapter](https://lists.lrz.de/mailman/listinfo/rse) to learn more.
+After the talks/discussion, we will continue to a Christmas market. Join the [mailing list of our chapter](https://lists.lrz.de/mailman/listinfo/rse) to learn more.
+
+[Invitation / Meeting notes](https://pad.okfn.de/p/rse-muc-meetup4-23) - Add yourself if you are planning to participate.
 
 ## Past activity
 
+- 2023-10-12: Third meeting in 2023, at LMU - [Meeting notes](https://pad.okfn.de/p/rse-muc-meetup3-23)
+   - Talk by Raphael Ritz: NFDI Jupyter Hub
+   - Talk by Michele Martone: Brief Basic Introduction in Semantic Patching with Coccinelle
 - 2023-06-29: Second meeting in 2023, at LMU - [Meeting notes](https://pad.okfn.de/p/rse-mus-meetup2-23)
   - Open discussion about [DataCite](https://datacite.org/) and ways to cite software, the [NFDI](https://www.nfdi.de/) initiative and the RSE working group, the [de-RSE Unconference](https://un-derse23.sciencesconf.org/), and the [Digital Research Academy](https://heidiseibold.ck.page/posts/feedback-wanted-building-a-digital-research-academy).
 - 2023-03-15: First meeting in 2023, at LMU - [Meeting notes](https://pad.okfn.de/p/rse-muc-meetup1-23)


### PR DESCRIPTION
Adds the agenda of the next [Munich RSE](https://de-rse.org/chapter/muc/) meeting, with talks by @Ballhausen and @michelemartone.

@knarrff thank you for merging! :hugs: 