### PR TITLE
MUC: Add June 2024 meeting, archive April meeting

### DIFF
--- a/_pages/muc/index.md
+++ b/_pages/muc/index.md
@@ -14,19 +14,22 @@ _A part of our group (with unfortunately many people missing) met at [deRSE24](h
 
 ## News
 
-**Next meeting:** April 11, 2024, 17:00-18:45 at the LMU University Library, Room F324, Geschwister-Scholl-Platz 1
+**Next meeting:** June 20, 2024, 17:00-18:45 at the [Leibniz Supercomputing Centre](https://www.lrz.de/english/) (Garching, U6: Garching-Forschungszentrum).
 
 Agenda:
 
-- Talk by Dominik Leipold (LMU): Digital Infrastructure and RSE for the Critical Edition of the Works of Richard Strauss
-- Looking for a second speaker, see contact details at the end
+- Talk by Ivan Pribec (LRZ): Introducing the Fortran-Lang community
+- Talk by Friedrich Ulrich and Benjamin Farnbacher (TUM): Research Data Management in HPMC: Applications & Best Practices
 
-Afterwards: Dinner together.
+Afterwards: Dinner together at the [Garnix](https://garnix-openair.de/) festival.
 
-[Invitation / Meeting notes](https://pad.okfn.de/p/rse-muc-meetup2-24) - Add yourself if you are planning to participate.
+[Invitation / Meeting notes](https://pad.okfn.de/p/rse-muc-meetup3-24) - Add yourself if you are planning to participate.
 
 ## Past activity
 
+- 2024-04-11: Second meeting in 2024, at LMU - [Meeting notes](https://pad.okfn.de/p/rse-muc-meetup2-24)
+  - Talk by Dominik Leipold (LMU): Digital Infrastructure and RSE for the Critical Edition of the Works of Richard Strauss
+  - Talk by Jonas Hagenberg (MPI of Psychiatry): The code club at the MPI  of Psychiatry
 - 2024-02-22: First meeting in 2024, at the Max Planck Digital Library - [Meeting notes](https://pad.okfn.de/p/rse-muc-meetup1-24)
   - Talk by Benjamin Rodenberg (TUM): CodeOcean, Binder and Reproducible Python
   - Talk by Björn Brötz (DLR): An open-source electronic laboratory notebook

--- a/_pages/muc/index.md
+++ b/_pages/muc/index.md
@@ -19,7 +19,7 @@ _A part of our group (with unfortunately many people missing) met at [deRSE24](h
 Agenda:
 
 - Talk by Ivan Pribec (LRZ): Introducing the Fortran-Lang community
-- Talk by Friedrich Ulrich and Benjamin Farnbacher (TUM): Research Data Management in HPC: Applications & Best Practices
+- Talk by Friedrich Ulrich and Benjamin Farnbacher (TUM): Research Data Management in HPMC: Applications & Best Practices
 
 Afterwards: Dinner together at the [Garnix](https://garnix-openair.de/) festival.
 

--- a/_pages/muc/index.md
+++ b/_pages/muc/index.md
@@ -19,7 +19,7 @@ _A part of our group (with unfortunately many people missing) met at [deRSE24](h
 Agenda:
 
 - Talk by Ivan Pribec (LRZ): Introducing the Fortran-Lang community
-- Talk by Friedrich Ulrich and Benjamin Farnbacher (TUM): Research Data Management in HPMC: Applications & Best Practices
+- Talk by Friedrich Ulrich and Benjamin Farnbacher (TUM): Research Data Management in HPC: Applications & Best Practices
 
 Afterwards: Dinner together at the [Garnix](https://garnix-openair.de/) festival.
 


### PR DESCRIPTION
Munich chapter:

- Adds the June 2024 meeting
- Archives the April 2024 meeting

Speakers have already confirmed.

@michelemartone ok?