### PR TITLE
MUC: Update contact people

### DIFF
--- a/_pages/muc/index.md
+++ b/_pages/muc/index.md
@@ -58,9 +58,9 @@ Afterwards: Dinner together at [Potlatsch](https://potlatsch-muenchen.de/).
 We organize ourselves mainly over the [Mailing list](https://lists.lrz.de/mailman/listinfo/rse) and a [Matrix channel](https://matrix.to/#/#derse-chapter-muc:gitter.im). Definitely join us there to learn about upcoming events and other activities.
 
 For questions regarding the group, feel free to contact, for example:
-  - [Heidi Seibold](https://heidiseibold.com/)
+  - [Larissa Leiminger](https://www.mpdl.mpg.de/en/about-us/team.html) - MPDL
   - [Martin Spenger](https://www.ub.uni-muenchen.de/ueber-die-ub/kontakt/personen/spenger/index.html) - LMU
-  - [Gerasimos Chourdakis](https://www.cs.cit.tum.de/en/sccs/people/gerasimos-chourdakis/) - TUM
+  - [Gerasimos Chourdakis](https://www.cs.cit.tum.de/en/sccs/people/gerasimos-chourdakis/) - Univ. Stuttgart / TUM
 
 **Sprache:** Um die Reichweite der Gruppe zu maximieren und mit Rücksicht auf die vielen nicht-deutschen Studenten, Doktoranden und Forscher in München, ist die Arbeitssprache der Gruppe Englisch. Natürlich bleibt Deutsch immer eine Option für die Diskussionen.
 


### PR DESCRIPTION
In our first meeting of 2025, we looked at the webpage of the group and decided to update the people listed here based on the current activity. This PR adds @LeimLarissa, removes @HeidiSeibold for now, and updates my affiliation. @MSpenger remains on the list as well.

This list serves mostly as an impulse to new people in these institutes to have a first point of contact, without yet messaging a public channel.

Anything else we should update?