### PR TITLE
Add a CI workflow to build the website

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build the website
+
+on:
+  pull_request:
+
+jobs:
+  build-website:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build
+        uses: actions/jekyll-build-pages@v1
+        with:
+          destination: "./built-website"
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: "./built-website"


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds the website and uploads a build artifact to check. This should catch some basic issues in pull requests.

Based on this official GitHub Action: https://github.com/marketplace/actions/build-jekyll-for-github-pages

If this works out, I could follow up with an extension of this to deploy previews (see https://github.com/MakisH/de-rse-chapter/pull/1). I already played a bit, but it seems to need a bit more work. I will not continue on that anytime soon.